### PR TITLE
fix: use a black recording countdown and record the actual UI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,8 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm test:release-tools
       - run: pnpm build
-      - run: python -m pip install playwright==1.55.0
-      - run: python scripts/qa/countdown-ui.py
+      - run: python -m pip install playwright==1.55.0 imageio-ffmpeg==0.6.0
+      - run: python scripts/qa/countdown-ui.py --record
       - uses: actions/upload-artifact@v7
         if: always()
         with:

--- a/docs/adr/0026-recording-countdown-readiness.md
+++ b/docs/adr/0026-recording-countdown-readiness.md
@@ -37,3 +37,14 @@ remounts, session identity, initial control state, and a recording starting only
 once. Run packaged-app acceptance on supported desktop systems; browser UI
 tests alone do not verify native focus, display affinity or multi-monitor
 placement.
+
+## Palette refinement — 2026-09-06
+
+After reviewing the implementation, the maintainer requested black rather than
+coral. The ring, numerals, stop icon, cancel label and keyboard focus indicator
+now use near-black (#111111); the track, borders and interaction states use
+neutral grays. Keep the small white readability disc and transparent outer
+surface. Geometry, timing, session safety and native capture exclusion do not
+change. Built-renderer tests verify the palette and export an optional
+high-resolution recording of the actual component, with IPC isolated in the
+harness rather than weakening native capture protection.

--- a/scripts/qa/countdown-ui.py
+++ b/scripts/qa/countdown-ui.py
@@ -1,12 +1,23 @@
-"""UI regression against the built app; mocks IPC only, never changes shipped code."""
-import asyncio, functools, json, threading
-from pathlib import Path
+"""Check the built countdown UI; only native IPC is replaced in this test harness."""
+import argparse
+import asyncio
+import functools
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+import threading
+import time
 from http.server import SimpleHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 from playwright.async_api import async_playwright
 
-OUT=Path('countdown-review');OUT.mkdir(exist_ok=True)
-SESSION='a6c9a5df-cf18-41ae-a435-72c837d226d1'
-BRIDGE='''(() => {
+OUT = Path('countdown-review')
+OUT.mkdir(exist_ok=True)
+SESSION = 'a6c9a5df-cf18-41ae-a435-72c837d226d1'
+BRIDGE = '''(() => {
 window.calls=[];window.ready=false;window.releaseReady=()=>{window.ready=true};
 const callbacks=new Map();let serial=0;
 window.__TAURI_INTERNALS__={
@@ -25,39 +36,178 @@ if(c==='plugin:event|listen')return ++serial;
 return null;
 }};window.__TAURI_EVENT_PLUGIN_INTERNALS__={unregisterListener:()=>{}};
 })();'''
+
 class Handler(SimpleHTTPRequestHandler):
- def log_message(self,*args):pass
-async def main():
- server=ThreadingHTTPServer(('127.0.0.1',8765),functools.partial(Handler,directory='dist'))
- threading.Thread(target=server.serve_forever,daemon=True).start();results=[]
- async with async_playwright() as p:
-  browser=await p.chromium.launch(channel='chrome')
-  async def page(kind='countdown',extra=''):
-   context=await browser.new_context(viewport={'width':960,'height':640})
-   await context.route('**/*',lambda route:route.continue_() if route.request.url.startswith('http://127.0.0.1:8765/') else route.abort())
-   await context.add_init_script(script=BRIDGE+extra)
-   win=await context.new_page();await win.goto(f'http://127.0.0.1:8765/?window={kind}&session={SESSION}')
-   return context,win
-  async def count(win,cmd):return await win.evaluate('(c)=>calls.filter(x=>x.command===c).length',cmd)
-  c,w=await page();await w.get_by_role('button',name='Cancel Countdown').wait_for()
-  await w.wait_for_timeout(3300);assert await count(w,'begin_recording')==0
-  await w.screenshot(path=str(OUT/'countdown-actual.png'))
-  await w.evaluate('releaseReady()');await w.get_by_role('status',name='Recording starts in 2').wait_for()
-  await w.get_by_role('status',name='Recording starts in 1').wait_for();await w.wait_for_timeout(1300)
-  assert await count(w,'begin_recording')==1
-  args=await w.evaluate("calls.find(c=>c.command==='begin_recording').args")
-  assert args=={'sessionId':SESSION};results.append('ready -> 3 -> 2 -> 1 -> one native start');await c.close()
-  for key in ['click','Escape']:
-   c,w=await page();button=w.get_by_role('button',name='Cancel Countdown');await button.wait_for();await w.evaluate('releaseReady()');await w.wait_for_timeout(200)
-   if key=='click':await button.click()
-   else:await w.keyboard.press('Escape')
-   await w.wait_for_timeout(3200);assert await count(w,'begin_recording')==0;assert await count(w,'cancel_recording_flow')==1
-   results.append(key+' cancels before expiry');await c.close()
-  c,w=await page(extra='window.failCancel=true;');button=w.get_by_role('button',name='Cancel Countdown');await button.click()
-  await w.get_by_role('alert').wait_for();await button.click();await w.evaluate('releaseReady()');await w.wait_for_timeout(3300)
-  assert await count(w,'cancel_recording_flow')==2;assert await count(w,'begin_recording')==0;results.append('failed cancellation can retry without restarting');await c.close()
-  c,w=await page('control-panel');await w.get_by_role('button',name='Cancel',exact=True).wait_for()
-  assert await w.get_by_role('button',name='Cancel',exact=True).is_enabled();results.append('late control panel hydrates its cancel action');await c.close()
-  await browser.close()
- server.shutdown();(OUT/'ui-tests.json').write_text(json.dumps({'passed':results,'native':False},indent=2))
-asyncio.run(main())
+    def log_message(self, *args):
+        pass
+
+async def count(win, command):
+    return await win.evaluate('(c)=>calls.filter(x=>x.command===c).length', command)
+
+async def verify_palette(win):
+    palette = await win.evaluate('''() => {
+      const style = s => getComputedStyle(document.querySelector(s));
+      return {
+        number: style('.kiri-countdown-number').color,
+        progress: style('.kiri-countdown-progress').stroke,
+        stop: style('.kiri-countdown-stop').backgroundColor,
+        button: style('.kiri-countdown-cancel').color,
+        track: style('.kiri-countdown-track').stroke,
+        backdrop: style('.kiri-countdown').backgroundColor
+      };
+    }''')
+    for key in ['number', 'progress', 'stop', 'button']:
+        assert palette[key] == 'rgb(17, 17, 17)', (key, palette)
+    assert palette['track'] == 'rgb(229, 229, 229)'
+    assert palette['backdrop'] == 'rgba(0, 0, 0, 0)'
+    button = win.get_by_role('button', name='Cancel Countdown')
+    await button.hover()
+    await win.wait_for_timeout(160)
+    assert await button.evaluate('(e)=>getComputedStyle(e).backgroundColor') == 'rgb(245, 245, 245)'
+    await win.mouse.move(0, 0)
+    await button.focus()
+    assert await button.evaluate('(e)=>getComputedStyle(e).outlineColor') == 'rgb(17, 17, 17)'
+    return palette
+
+async def record_run(browser, make_page):
+    """Capture device-resolution frames with real timestamps, not redrawn UI."""
+    context, win = await make_page(viewport={'width': 960, 'height': 540}, scale=2)
+    try:
+        await win.get_by_role('button', name='Cancel Countdown').wait_for()
+        await win.evaluate('document.fonts.ready')
+        await win.screenshot(path=str(OUT/'countdown-black.png'), scale='device')
+        observed = []
+        frames = []
+        with tempfile.TemporaryDirectory(prefix='kiri-countdown-') as directory:
+            root = Path(directory)
+            start = time.monotonic()
+            await win.evaluate('releaseReady()')
+            while time.monotonic() - start < 5:
+                tick = await win.locator('.kiri-countdown-number').inner_text()
+                if tick not in observed:
+                    observed.append(tick)
+                path = root/f'{len(frames):04d}.png'
+                stamp = time.monotonic()
+                await win.screenshot(path=str(path), scale='device')
+                frames.append((path, stamp))
+                if await count(win, 'begin_recording'):
+                    break
+                await asyncio.sleep(0.025)
+            assert observed == ['3', '2', '1'], observed
+            assert await count(win, 'begin_recording') == 1
+            # One uninterrupted renderer run at actual speed. No scene cuts,
+            # artificial result holds, zooming or source-image enlargement.
+            listing = []
+            for index, (path, stamp) in enumerate(frames):
+                listing.append(f"file '{path.as_posix()}'")
+                if index + 1 < len(frames):
+                    listing.append(f'duration {frames[index+1][1]-stamp:.8f}')
+            playlist = root/'frames.txt'
+            playlist.write_text('\n'.join(listing)+'\n', encoding='utf-8')
+            encoder = shutil.which('ffmpeg')
+            if not encoder:
+                import imageio_ffmpeg
+                encoder = imageio_ffmpeg.get_ffmpeg_exe()
+            target = OUT/'countdown-black.mp4'
+            subprocess.run([encoder, '-hide_banner', '-loglevel', 'error', '-y',
+                '-f', 'concat', '-safe', '0', '-i', str(playlist),
+                '-vf', 'fps=30', '-an', '-c:v', 'libx264', '-preset', 'fast',
+                '-crf', '16', '-pix_fmt', 'yuv420p', '-movflags', '+faststart',
+                str(target)], check=True)
+        manifest = {
+            'source_commit': os.environ.get('GITHUB_SHA'),
+            'visual_source': 'Actual built CountdownWindow component and countdown.css',
+            'native_ipc': 'Isolated test stub; not a native desktop recording',
+            'size': [1920, 1080], 'device_scale_factor': 2,
+            'speed_factor': 1, 'scene_cuts': 0, 'extra_holds': 0,
+            'observed_numerals': observed, 'frames': len(frames),
+            'observed_seconds': frames[-1][1]-frames[0][1],
+            'sha256': hashlib.sha256(target.read_bytes()).hexdigest(),
+        }
+        (OUT/'video-provenance.json').write_text(json.dumps(manifest, indent=2)+'\n')
+    finally:
+        await context.close()
+
+async def main(record=False):
+    server = ThreadingHTTPServer(('127.0.0.1', 8765), functools.partial(Handler, directory='dist'))
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    results = []
+    try:
+        async with async_playwright() as p:
+            browser = await p.chromium.launch(channel='chrome')
+            async def page(kind='countdown', extra='', viewport=None, scale=1, reduced_motion='no-preference'):
+                context = await browser.new_context(viewport=viewport or {'width': 960, 'height': 640},
+                    device_scale_factor=scale, reduced_motion=reduced_motion)
+                await context.route('**/*', lambda route: route.continue_() if route.request.url.startswith('http://127.0.0.1:8765/') else route.abort())
+                await context.add_init_script(script=BRIDGE+extra)
+                win = await context.new_page()
+                await win.goto(f'http://127.0.0.1:8765/?window={kind}&session={SESSION}')
+                return context, win
+
+            c, w = await page()
+            await w.get_by_role('button', name='Cancel Countdown').wait_for()
+            palette = await verify_palette(w)
+            results.append('black numerals, progress, stop icon, button and focus; neutral hover; transparent backdrop')
+            await w.wait_for_timeout(3300)
+            assert await count(w, 'begin_recording') == 0
+            await w.screenshot(path=str(OUT/'countdown-actual.png'))
+            await w.evaluate('releaseReady()')
+            await w.get_by_role('status', name='Recording starts in 2').wait_for()
+            await w.get_by_role('status', name='Recording starts in 1').wait_for()
+            await w.wait_for_timeout(1300)
+            assert await count(w, 'begin_recording') == 1
+            assert await w.evaluate("calls.find(c=>c.command==='begin_recording').args") == {'sessionId': SESSION}
+            results.append('ready -> 3 -> 2 -> 1 -> one native start')
+            await c.close()
+            for key in ['click', 'Escape']:
+                c, w = await page()
+                button = w.get_by_role('button', name='Cancel Countdown')
+                await button.wait_for()
+                await w.evaluate('releaseReady()')
+                await w.wait_for_timeout(200)
+                if key == 'click':
+                    await button.click()
+                else:
+                    await w.keyboard.press('Escape')
+                await w.wait_for_timeout(3200)
+                assert await count(w, 'begin_recording') == 0
+                assert await count(w, 'cancel_recording_flow') == 1
+                results.append(key+' cancels before expiry')
+                await c.close()
+            c, w = await page(extra='window.failCancel=true;')
+            button = w.get_by_role('button', name='Cancel Countdown')
+            await button.click()
+            await w.get_by_role('alert').wait_for()
+            await button.click()
+            await w.evaluate('releaseReady()')
+            await w.wait_for_timeout(3300)
+            assert await count(w, 'cancel_recording_flow') == 2
+            assert await count(w, 'begin_recording') == 0
+            results.append('failed cancellation can retry without restarting')
+            await c.close()
+            c, w = await page('control-panel')
+            await w.get_by_role('button', name='Cancel', exact=True).wait_for()
+            assert await w.get_by_role('button', name='Cancel', exact=True).is_enabled()
+            results.append('late control panel hydrates its cancel action')
+            await c.close()
+            c, w = await page(viewport={'width': 320, 'height': 320}, reduced_motion='reduce')
+            await w.get_by_role('button', name='Cancel Countdown').wait_for()
+            await verify_palette(w)
+            bounds = await w.get_by_role('button', name='Cancel Countdown').bounding_box()
+            assert bounds and bounds['x'] >= 0 and bounds['x']+bounds['width'] <= 320
+            assert bounds['y'] >= 0 and bounds['y']+bounds['height'] <= 320
+            results.append('compact window and reduced motion keep the black controls visible')
+            await c.close()
+            if record:
+                await record_run(browser, page)
+                results.append('recorded one real built-renderer 3-2-1 at device resolution')
+            await browser.close()
+    finally:
+        server.shutdown()
+        server.server_close()
+    (OUT/'ui-tests.json').write_text(json.dumps({'passed': results, 'palette': palette, 'native': False}, indent=2)+'\n')
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--record', action='store_true')
+    asyncio.run(main(record=parser.parse_args().record))

--- a/src/windows/countdown.css
+++ b/src/windows/countdown.css
@@ -4,7 +4,7 @@
   display: grid;
   place-items: center;
   background: transparent;
-  --countdown-coral: #ff4d55;
+  --countdown-ink: #111111;
 }
 .kiri-countdown-ring {
   position: relative;
@@ -15,14 +15,14 @@
 .kiri-countdown-disc { fill: rgba(255, 255, 255, 0.96); }
 .kiri-countdown-track,
 .kiri-countdown-progress { fill: none; stroke-width: 6; }
-.kiri-countdown-track { stroke: #ffe1e3; }
-.kiri-countdown-progress { stroke: var(--countdown-coral); stroke-linecap: round; }
+.kiri-countdown-track { stroke: #e5e5e5; }
+.kiri-countdown-progress { stroke: var(--countdown-ink); stroke-linecap: round; }
 .kiri-countdown-number {
   position: absolute;
   inset: 0;
   display: grid;
   place-items: center;
-  color: var(--countdown-coral);
+  color: var(--countdown-ink);
   font-family: ui-rounded, "SF Pro Rounded", "Segoe UI Variable Display", system-ui, sans-serif;
   font-size: 82px;
   font-weight: 600;
@@ -41,21 +41,21 @@
   gap: 9px;
   min-height: 40px;
   padding: 0 14px;
-  border: 1px solid #e7cdd0;
+  border: 1px solid #d4d4d4;
   border-radius: 999px;
   background: #fff;
-  color: #81333c;
+  color: var(--countdown-ink);
   font: 500 13px/1 var(--kiri-font-ui);
   white-space: nowrap;
   cursor: pointer;
   transition: background-color 120ms ease, border-color 120ms ease;
 }
-.kiri-countdown-cancel:hover:not(:disabled) { background: #fff0f1; border-color: #ffadb2; }
-.kiri-countdown-cancel:active:not(:disabled) { background: #ffe1e3; transform: translateX(-50%); }
-.kiri-countdown-cancel:focus-visible { outline: 2px solid var(--countdown-coral); outline-offset: 3px; }
+.kiri-countdown-cancel:hover:not(:disabled) { background: #f5f5f5; border-color: #a3a3a3; }
+.kiri-countdown-cancel:active:not(:disabled) { background: #e5e5e5; transform: translateX(-50%); }
+.kiri-countdown-cancel:focus-visible { outline: 2px solid var(--countdown-ink); outline-offset: 3px; }
 .kiri-countdown-cancel:disabled { opacity: 0.55; cursor: wait; }
-.kiri-countdown-stop { width: 9px; height: 9px; border-radius: 2px; background: var(--countdown-coral); }
-.kiri-countdown-cancel kbd { margin-left: 4px; font: 11px/1 var(--kiri-font-ui); color: #827075; }
+.kiri-countdown-stop { width: 9px; height: 9px; border-radius: 2px; background: var(--countdown-ink); }
+.kiri-countdown-cancel kbd { margin-left: 4px; font: 11px/1 var(--kiri-font-ui); color: #737373; }
 .kiri-countdown-error {
   position: absolute;
   top: calc(100% + 63px);
@@ -66,7 +66,7 @@
   padding: 10px;
   border-radius: 8px;
   background: #fff;
-  color: #8b2831;
+  color: #404040;
   text-align: center;
   font: 13px/1.5 var(--kiri-font-ui);
 }


### PR DESCRIPTION
Changes the shipped countdown stylesheet from coral to near-black (#111111): ring, numerals, stop icon, cancel label and keyboard focus indicator. Track, border, hover, pressed and error text are neutral grays. Keeps geometry, white readability disc, transparent outer surface, all native readiness/session fixes and capture exclusion unchanged.

The existing built-renderer checks now assert the palette and compact/reduced-motion visibility. Readiness, one-start, mouse/Escape cancellation, cancellation retry and late control-panel hydration checks are retained. The read-only renderer CI job records actual device-resolution frames from the built CountdownWindow, with real timestamps and no drawn replacement UI. Native IPC is isolated in that renderer harness; the recording is not represented as native screen capture.

Validation at f81cb590bccb867e0a819eb415f905623b7880a4: ALL five jobs passed in Actions run 34022248971, including renderer/release-tool checks, macOS Rust tests, macOS arm64/x64 compilation, Windows Rust tests/release compilation and actual Windows countdown/recording-control acceptance. No macOS native desktop GUI test is claimed.

Renderer artifact 9985893052 contains the verified 1920×1080 H.264 recording: 3.033 seconds, numerals 3 -> 2 -> 1, real-time playback, one continuous run, zero scene cuts or extra holds. Video SHA256 f59644a547f8f8eaa8a675a8fa6916126b3be63593fb6a3f6df242b5eeff37aa. Full decode, actual dimensions, checksum, palette report and representative encoded frames were reviewed. Eight renderer checks passed.

The palette refinement is recorded in ADR 0026. Final diff is four files: stylesheet, renderer QA, two read-only renderer-CI lines and ADR appendix. No native code, application dependencies, recording-protection changes, version bump, release or replacement of the already-published full project demos.